### PR TITLE
FIXED Incorrect repo url in package.json!

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glitch-info",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A simple package that returns info on your Glitch profile, teams and collections in JSON format.",
   "main": "server.js",
   "scripts": {
@@ -14,7 +14,7 @@
     "node": "12.x"
   },
   "repository": {
-    "url": "https://github.com/edit/#!/hello-express"
+    "url": "https://github.com/khalby786/glitch-info"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
The `package.json` had an incorrect url of the package's GitHub repo, which showed up in the NPM page.